### PR TITLE
Fixing the __str__ function for Segment in python 3.

### DIFF
--- a/bincopy.py
+++ b/bincopy.py
@@ -208,7 +208,7 @@ class _Segment(object):
     def __str__(self):
         return '[%#x .. %#x]: %s' % (self.minimum,
                                      self.maximum,
-                                     ''.join([binascii.hexlify(d)
+                                     ''.join([binascii.hexlify(d).decode('utf-8')
                                               for d in self.data]))
 
 


### PR DESCRIPTION
Still works in python2 however in python3 byte arrays arent interchangable with strings (as easily)
